### PR TITLE
fix(kafka): Update default topic name

### DIFF
--- a/py/usageaccountant/accumulator.py
+++ b/py/usageaccountant/accumulator.py
@@ -34,7 +34,7 @@ class UsageKey(NamedTuple):
     unit: UsageUnit
 
 
-DEFAULT_TOPIC_NAME = "resources_usage_log"
+DEFAULT_TOPIC_NAME = "shared-resources-usage"
 DEFAULT_QUEUE_SIZE = 9500
 CLOSE_TIMEOUT_SEC = 60
 


### PR DESCRIPTION
The shared topic in production is named `shared-resources-usage`