### PR TITLE
Fix missing dependency on arroyo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: venv
 .PHONY: venv-python
 venv-python:
 	virtualenv -ppython3 $(VENV_PATH)
-	pip install -r py/requirements.txt
+	pip install -e .
 
 
 .PHONY: test-python

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -12,6 +12,9 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]
+dependencies = [
+    'sentry-arroyo==2.14.5'
+]
 
 [tool.black]
 line-length = 79

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,1 +1,0 @@
-sentry-arroyo==2.14.5


### PR DESCRIPTION
The dependency had to be declared in the pyproject.toml file