### PR TITLE
fix(dependencies): Update Arroyo to >= 2.14.5

### DIFF
--- a/py/requirements-test.txt
+++ b/py/requirements-test.txt
@@ -1,4 +1,4 @@
-sentry-arroyo==2.14.6
+sentry-arroyo>=2.14.5
 pytest>=7.2.1
 mypy>=1.4.1
 black==22.3.0

--- a/py/requirements-test.txt
+++ b/py/requirements-test.txt
@@ -1,4 +1,4 @@
-sentry-arroyo==2.14.5
+sentry-arroyo==2.14.6
 pytest>=7.2.1
 mypy>=1.4.1
 black==22.3.0


### PR DESCRIPTION
This library fails to install in Snuba because of mismatched dependency versions for Arroyo:

```
ERROR: Cannot install snuba and snuba==23.9.0.dev0 because these package versions have conflicting dependencies.

The conflict is caused by:
    snuba 23.9.0.dev0 depends on sentry-arroyo==2.14.6
    sentry-usage-accountant 0.0.3 depends on sentry-arroyo==2.14.5
```