### PR TITLE
feat(typing): Python library stubs (py.typed)

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -16,6 +16,12 @@ dependencies = [
     'sentry-arroyo>=2.14.5'
 ]
 
+[tool.setuptools.package-data]
+usageaccountant = ["py.typed"]
+
+[tool.setuptools.packages.find]
+where = ["usageaccountant"]
+
 [tool.black]
 line-length = 79
 target-version = ['py38']


### PR DESCRIPTION
When using this library in other projects, the following mypy error arises as a result of missing library stubs:
```
error: Skipping analyzing "usageaccountant": module is installed,
       but missing library stubs or py.typed marker  [import]
```

This PR _should_ fix this.