### PR TITLE
pre-commit: add trufflehog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,5 +36,15 @@ repos:
           sentry-arroyo==2.14.5,
         ]
         files: ^py/.+
+  - repo: local
+    hooks:
+      - id: trufflehog
+        name: TruffleHog
+        description: Detect secrets in your data.
+        entry: bash -c 'trufflehog git file://. --since-commit HEAD --only-verified --fail'
+        # For running trufflehog in docker, use the following entry instead:
+        # entry: bash -c 'docker run --rm -v "$(pwd):/workdir" -i --rm trufflesecurity/trufflehog:latest git file:///workdir --since-commit HEAD --only-verified --fail'
+        language: system
+        stages: ["commit", "push"]
 default_language_version:
   python: python3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
   - repo: local
     hooks:
       - id: trufflehog
-        name: TruffleHog
+        name: trufflehog
         description: Detect secrets in your data.
         entry: bash -c 'trufflehog git file://. --since-commit HEAD --only-verified --fail'
         # For running trufflehog in docker, use the following entry instead:


### PR DESCRIPTION
This adds TruffleHog to pre-commit. It does assume that trufflehog is in your PATH. 
It can be installed with `brew install trufflehog`. 