### PR TITLE
all-repos: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
           pip install wheel
           pip install build
           python -m build --wheel
-      - uses: actions/upload-artifact@v3.1.1
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: py/dist/*


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos