### PR TITLE
handling cases when amount recorded is None

### DIFF
--- a/py/tests/test_data/datadog_response.py
+++ b/py/tests/test_data/datadog_response.py
@@ -67,3 +67,15 @@ processed_response = {
         }
     ]
 }
+
+processed_response_with_none = {
+    "series": [
+        {
+            "scope_dict": {
+                "app_feature": "shared",
+                "shared_resource_id": "rc_long_redis",
+            },
+            "pointlist": [[1721083885000.0, 2.5], [1721083890000.0, None]],
+        }
+    ]
+}

--- a/py/tests/test_fetcher.py
+++ b/py/tests/test_fetcher.py
@@ -166,20 +166,17 @@ class TestDatadogFetcher(unittest.TestCase):
             )
         ]
 
-        with self.assertLogs("fetcher") as cm:
-            self.assertEqual(
-                ddf.process_series_data(
-                    cast(
-                        Sequence[ddf.DatadogResponseSeries],
-                        self.processed_response_with_none["series"],
-                    ),
-                    accumulator.UsageUnit.BYTES,
-                    "rc_long_redis",
+        self.assertEqual(
+            ddf.process_series_data(
+                cast(
+                    Sequence[ddf.DatadogResponseSeries],
+                    self.processed_response_with_none["series"],
                 ),
-                expected_record_list,
-            )
-
-            assert len(cm.output) == 1
+                accumulator.UsageUnit.BYTES,
+                "rc_long_redis",
+            ),
+            expected_record_list,
+        )
 
     @patch("usageaccountant.datadog_fetcher.query_datadog")
     @patch("time.time")

--- a/py/usageaccountant/datadog_fetcher.py
+++ b/py/usageaccountant/datadog_fetcher.py
@@ -294,15 +294,18 @@ def process_series_data(
     for series in series_list:
         app_feature = series["scope_dict"]["app_feature"]
         for point in series["pointlist"]:
-            record_list.append(
-                UsageAccumulatorRecord(
+            try:
+                record = UsageAccumulatorRecord(
                     resource_id=shared_resource_id,
                     app_feature=app_feature,
                     # point[0] is the timestamp
                     amount=int(point[1]),
                     usage_type=parsed_unit,
                 )
-            )
+            except TypeError as e:
+                logger.warning(e, exc_info=True)
+                continue
+            record_list.append(record)
 
     return record_list
 

--- a/py/usageaccountant/datadog_fetcher.py
+++ b/py/usageaccountant/datadog_fetcher.py
@@ -294,18 +294,17 @@ def process_series_data(
     for series in series_list:
         app_feature = series["scope_dict"]["app_feature"]
         for point in series["pointlist"]:
-            try:
-                record = UsageAccumulatorRecord(
-                    resource_id=shared_resource_id,
-                    app_feature=app_feature,
-                    # point[0] is the timestamp
-                    amount=int(point[1]),
-                    usage_type=parsed_unit,
+            # skip records where there's no data recorded by Datadog
+            if point[1] is not None:
+                record_list.append(
+                    UsageAccumulatorRecord(
+                        resource_id=shared_resource_id,
+                        app_feature=app_feature,
+                        # point[0] is the timestamp
+                        amount=int(point[1]),
+                        usage_type=parsed_unit,
+                    )
                 )
-            except TypeError as e:
-                logger.warning(e, exc_info=True)
-                continue
-            record_list.append(record)
 
     return record_list
 


### PR DESCRIPTION
There are data points where amount recorded is `None`, for eg.
```
'pointlist': [
        [
          1721083881000.0,
          445.0
        ],
        [
          1721083885000.0,
          None
        ]
```
skipping those records.