### PR TITLE
feat(security): allow to pass SASL password via env variable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: "Prepare artifacts"
         working-directory: ./py
         run: |

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/py-ci.yaml
+++ b/.github/workflows/py-ci.yaml
@@ -20,7 +20,7 @@ jobs:
         name: Checkout code
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install dependencies
         working-directory: ./py
         run: |
@@ -40,7 +40,7 @@ jobs:
         name: Checkout code
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install dependencies
         working-directory: ./py
         run: |
@@ -60,7 +60,7 @@ jobs:
         name: Checkout code
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install dependencies
         working-directory: ./py
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args: [--config-file, py/mypy.ini, --strict]
         additional_dependencies: [
           pytest==7.1.2,
-          sentry-arroyo==2.14.5,
+          sentry-arroyo==2.22.0,
         ]
         files: ^py/.+
 default_language_version:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: 7.1.0
     hooks:
       - id: flake8
-        language_version: python3.8
+        language_version: python3.11
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v1.11.1'
     hooks:
@@ -37,4 +37,4 @@ repos:
         ]
         files: ^py/.+
 default_language_version:
-  python: python3.8
+  python: python3.11

--- a/py/mypy.ini
+++ b/py/mypy.ini
@@ -1,2 +1,2 @@
 [mypy]
-python_version = 3.8
+python_version = 3.11

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    'sentry-arroyo>=2.14.5'
+    'sentry-arroyo>=2.22.0'
 ]
 
 [tool.setuptools.package-data]

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -7,7 +7,7 @@ name = "sentry-usage-accountant"
 version = "0.0.11"
 description = "A library to account for shared resource usage"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",

--- a/py/requirements-test.txt
+++ b/py/requirements-test.txt
@@ -1,4 +1,4 @@
-sentry-arroyo>=2.14.5
+sentry-arroyo>=2.22.0
 pytest>=7.2.1
 mypy>=1.4.1
 black==24.3.0

--- a/py/tests/test_accountant.py
+++ b/py/tests/test_accountant.py
@@ -7,7 +7,7 @@ from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
 from arroyo.types import BrokerValue, Partition, Topic
-from arroyo.utils.clock import TestingClock
+from arroyo.utils.clock import MockedClock
 
 from usageaccountant import UsageAccumulator, UsageUnit
 
@@ -15,7 +15,7 @@ from usageaccountant import UsageAccumulator, UsageUnit
 @pytest.fixture
 def broker() -> LocalBroker[KafkaPayload]:
     storage: MemoryMessageStorage[KafkaPayload] = MemoryMessageStorage()
-    broker = LocalBroker(storage, TestingClock())
+    broker = LocalBroker(storage, MockedClock())
     topic = Topic("test_resource_usage")
     broker.create_topic(topic, 1)
     return broker

--- a/py/tests/test_fetcher.py
+++ b/py/tests/test_fetcher.py
@@ -75,12 +75,12 @@ class TestDatadogFetcher(unittest.TestCase):
         os.environ["SASL_PASSWORD"] = "supersecret"
 
         expected_kafka_config = accumulator.KafkaConfig(
-                bootstrap_servers=["kafka.service.host:1234"],
-                config_params={
-                    "sasl.username": "alice",
-                    "sasl.password": "supersecret",
-                }
-            )
+            bootstrap_servers=["kafka.service.host:1234"],
+            config_params={
+                "sasl.username": "alice",
+                "sasl.password": "supersecret",
+            },
+        )
 
         kafka_io = StringIO(
             '{"bootstrap_servers": ["kafka.service.host:1234"],'
@@ -90,8 +90,7 @@ class TestDatadogFetcher(unittest.TestCase):
         )
 
         self.assertEqual(
-            ddf.parse_and_assert_kafka_config(kafka_io),
-            expected_kafka_config
+            ddf.parse_and_assert_kafka_config(kafka_io), expected_kafka_config
         )
 
     def test_parse_and_assert_unit(self) -> None:

--- a/py/tests/test_fetcher.py
+++ b/py/tests/test_fetcher.py
@@ -7,7 +7,7 @@ from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
 from arroyo.types import Partition, Topic
-from arroyo.utils.clock import TestingClock
+from arroyo.utils.clock import MockedClock
 from typing_extensions import Mapping, Sequence, cast
 
 from tests.test_data import datadog_response
@@ -39,7 +39,7 @@ class TestDatadogFetcher(unittest.TestCase):
         )
 
         storage: MemoryMessageStorage[KafkaPayload] = MemoryMessageStorage()
-        self.broker = LocalBroker(storage, TestingClock())
+        self.broker = LocalBroker(storage, MockedClock())
         self.topic = Topic("test_dd_fetcher")
         self.broker.create_topic(self.topic, 1)
 

--- a/py/tests/test_fetcher.py
+++ b/py/tests/test_fetcher.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import unittest
 from io import StringIO
 from unittest.mock import Mock, patch
@@ -68,6 +69,29 @@ class TestDatadogFetcher(unittest.TestCase):
         )
         self.assertRaises(
             AssertionError, ddf.parse_and_assert_kafka_config, kafka_io
+        )
+
+    def test_parse_and_assert_expandvars(self) -> None:
+        os.environ["SASL_PASSWORD"] = "supersecret"
+
+        expected_kafka_config = accumulator.KafkaConfig(
+                bootstrap_servers=["kafka.service.host:1234"],
+                config_params={
+                    "sasl.username": "alice",
+                    "sasl.password": "supersecret",
+                }
+            )
+
+        kafka_io = StringIO(
+            '{"bootstrap_servers": ["kafka.service.host:1234"],'
+            '"config_params": '
+            '{"sasl.username": "alice",'
+            '"sasl.password": "${SASL_PASSWORD}"}}'
+        )
+
+        self.assertEqual(
+            ddf.parse_and_assert_kafka_config(kafka_io),
+            expected_kafka_config
         )
 
     def test_parse_and_assert_unit(self) -> None:

--- a/py/usageaccountant/accumulator.py
+++ b/py/usageaccountant/accumulator.py
@@ -13,9 +13,10 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
+    Union,
 )
 
-from arroyo.backends.abstract import Producer
+from arroyo.backends.abstract import Producer, SimpleProducerFuture
 from arroyo.backends.kafka.configuration import build_kafka_configuration
 from arroyo.backends.kafka.consumer import KafkaPayload, KafkaProducer
 from arroyo.types import BrokerValue, Topic
@@ -112,7 +113,12 @@ class UsageAccumulator:
             )
 
         self.__queue_size = queue_size
-        self.__futures: Deque[Future[BrokerValue[KafkaPayload]]] = deque()
+        self.__futures: Deque[
+            Union[
+                SimpleProducerFuture[BrokerValue[KafkaPayload]],
+                Future[BrokerValue[KafkaPayload]],
+            ]
+        ] = deque()
 
         self.__last_log: Optional[float] = None
 

--- a/py/usageaccountant/datadog_fetcher.py
+++ b/py/usageaccountant/datadog_fetcher.py
@@ -94,6 +94,9 @@ def parse_and_assert_kafka_config(kafka_config_file: TextIO) -> KafkaConfig:
     bootstrap_servers = kafka_config["bootstrap_servers"]
     config_params = kafka_config["config_params"]
 
+    if "sasl.password" in config_params:
+        config_params["sasl.password"] = os.path.expandvars(config_params["sasl.password"])
+
     assert isinstance(bootstrap_servers, Sequence)
     assert isinstance(config_params, Mapping)
 

--- a/py/usageaccountant/datadog_fetcher.py
+++ b/py/usageaccountant/datadog_fetcher.py
@@ -95,7 +95,9 @@ def parse_and_assert_kafka_config(kafka_config_file: TextIO) -> KafkaConfig:
     config_params = kafka_config["config_params"]
 
     if "sasl.password" in config_params:
-        config_params["sasl.password"] = os.path.expandvars(config_params["sasl.password"])
+        config_params["sasl.password"] = os.path.expandvars(
+            config_params["sasl.password"]
+        )
 
     assert isinstance(bootstrap_servers, Sequence)
     assert isinstance(config_params, Mapping)


### PR DESCRIPTION
* Would allow to substitute `${SASL_PASSWORD}` in the kafka config with the value of that env variable

Apart from that, some chores:
* TestingClock was renamed to MockedClock in https://github.com/getsentry/arroyo/pull/408
* Docker image is being build on python 3.11 so bumping ci tools to 3.11 as well