### PR TITLE
fix: Allow `feature` in addition to `app_feature`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: venv
 .PHONY: venv-python
 venv-python:
 	virtualenv -ppython3 $(VENV_PATH)
-	pip install -e .
+	cd py && pip install -e .
 
 
 .PHONY: test-python

--- a/py/tests/test_data/datadog_response.py
+++ b/py/tests/test_data/datadog_response.py
@@ -41,6 +41,49 @@ good_response = {
     "group_by": ["shared_resource_id"],
 }
 
+good_response_feature_tag = {
+    "status": "ok",
+    "res_type": "time_series",
+    "resp_version": 1,
+    "query": "avg: redis.mem.peak{feature: shared}"
+    "by{shared_resource_id}.rollup(5)",
+    "from_date": 1721083881000,
+    "to_date": 1721083891000,
+    "series": [
+        {
+            "unit": [
+                {
+                    "family": "bytes",
+                    "id": 2,
+                    "name": "byte",
+                    "short_name": "B",
+                    "plural": "bytes",
+                    "scale_factor": 1.0,
+                },
+                None,
+            ],
+            "query_index": 0,
+            "aggr": "avg",
+            "metric": "redis.mem.peak",
+            "tag_set": ["shared_resource_id: rc_long_redis"],
+            "expression": "avg: redis.mem.peak{shared_resource_id: "
+            "rc_long_redis,feature: shared}.rollup(5)",
+            "scope": "feature: shared, shared_resource_id: rc_long_redis",
+            "interval": 5,
+            "length": 2,
+            "start": 1721083885000,
+            "end": 1721083894000,
+            "pointlist": [[1721083885000.0, 2.5], [1721083890000.0, 3.6]],
+            "display_name": "redis.mem.peak",
+            "attributes": {},
+        }
+    ],
+    "values": [],
+    "times": [],
+    "message": "",
+    "group_by": ["shared_resource_id"],
+}
+
 bad_response = {
     "status": "error",
     "res_type": "time_series",

--- a/py/tests/test_fetcher.py
+++ b/py/tests/test_fetcher.py
@@ -31,6 +31,9 @@ class TestDatadogFetcher(unittest.TestCase):
 
     def setUp(self) -> None:
         self.good_response = copy.deepcopy(datadog_response.good_response)
+        self.good_response_feature_tag = copy.deepcopy(
+            datadog_response.good_response_feature_tag
+        )
         self.bad_response = copy.deepcopy(datadog_response.bad_response)
         self.processed_response = copy.deepcopy(
             datadog_response.processed_response
@@ -124,6 +127,12 @@ class TestDatadogFetcher(unittest.TestCase):
         series_list = ddf.parse_and_assert_response_series(self.good_response)
         assert len(series_list) == 1
 
+    def test_parse_and_assert_response_series_feature_tag(self) -> None:
+        series_list = ddf.parse_and_assert_response_series(
+            self.good_response_feature_tag
+        )
+        assert len(series_list) == 1
+
     def test_parse_and_assert_response_series_error(self) -> None:
         self.assertRaises(
             AssertionError,
@@ -197,6 +206,31 @@ class TestDatadogFetcher(unittest.TestCase):
                 ),
                 accumulator.UsageUnit.BYTES,
                 "rc_long_redis",
+            ),
+            expected_record_list,
+        )
+
+    def test_process_series_data_feature_tag(self) -> None:
+        expected_record_list = [
+            ddf.UsageAccumulatorRecord(
+                resource_id="rc_long_redis",
+                app_feature="shared",
+                amount=2,
+                usage_type=accumulator.UsageUnit.BYTES,
+            ),
+            ddf.UsageAccumulatorRecord(
+                resource_id="rc_long_redis",
+                app_feature="shared",
+                amount=3,
+                usage_type=accumulator.UsageUnit.BYTES,
+            ),
+        ]
+        parsed = ddf.parse_and_assert_response_series(
+            self.good_response_feature_tag
+        )
+        self.assertEqual(
+            ddf.process_series_data(
+                parsed, accumulator.UsageUnit.BYTES, "rc_long_redis"
             ),
             expected_record_list,
         )

--- a/py/usageaccountant/datadog_fetcher.py
+++ b/py/usageaccountant/datadog_fetcher.py
@@ -114,7 +114,7 @@ def assert_valid_query(query: str) -> None:
 
     query: Datadog query
     """
-    assert "app_feature" in query
+    assert "app_feature" in query or "feature" in query
 
 
 def assert_valid_unit(unit: str) -> None:
@@ -227,8 +227,8 @@ def parse_and_assert_response_scope(scope: str) -> Mapping[str, str]:
         assert len(sub_parts) == 2
         param_dict[sub_parts[0].strip()] = sub_parts[1].strip()
 
-    assert "app_feature" in param_dict, (
-        "Required parameters, app_feature not found "
+    assert "app_feature" in param_dict or "feature" in param_dict, (
+        "Required parameters, `app_feature` or `feature` not found "
         "in series.scope of the series received."
     )
 
@@ -297,7 +297,10 @@ def process_series_data(
     """
     record_list = []
     for series in series_list:
-        app_feature = series["scope_dict"]["app_feature"]
+        if "app_feature" in series["scope_dict"]:
+            app_feature = series["scope_dict"]["app_feature"]
+        elif "feature" in series["scope_dict"]:
+            app_feature = series["scope_dict"]["feature"]
         for point in series["pointlist"]:
             # skip records where there's no data recorded by Datadog
             if point[1] is not None:

--- a/py/usageaccountant/datadog_fetcher.py
+++ b/py/usageaccountant/datadog_fetcher.py
@@ -112,6 +112,12 @@ def assert_valid_query(query: str) -> None:
     Validates if query string contains
     app_feature–parameter used in UsageAccumulator.record().
 
+    We allow both `app_feature` and `feature` to account for
+    the scenario where a getsentry pod is labeled with `app_feature`,
+    but we *also* collect finer grained usage from within the container.
+    In this situation, the application metrics cannot use `app_feature`
+    as the tag value becomes `shared, issues`.
+
     query: Datadog query
     """
     assert "app_feature" in query or "feature" in query


### PR DESCRIPTION
Many of our sentry application pods are tagged with `app_feature` as a default tag. If those pods also contain a shared_resource_id, we end up with two values for the `app_feature` tag. By allowing `feature` as a tag as well, usage-accountant could handle this scenario.