### PR TITLE
feat: add "operations" unit

### DIFF
--- a/py/usageaccountant/accumulator.py
+++ b/py/usageaccountant/accumulator.py
@@ -26,6 +26,7 @@ class UsageUnit(Enum):
     MILLISECONDS = "milliseconds"
     BYTES = "bytes"
     MILLISECONDS_SEC = "milliseconds_sec"
+    OPERATIONS = "operations"
 
 
 class UsageKey(NamedTuple):


### PR DESCRIPTION
https://github.com/getsentry/objectstore/pull/492 is going to be consumed by the usage accountant datadog fetcher but it measures a count of operations, not time or bandwidth. this PR adds "operations" as a metric type

tbh i'm not sure where the unit descriptor is used in the pipeline, but whatever