### PR TITLE
build(docker): Pull base images from the dhi-mirror registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM us-docker.pkg.dev/sentryio/dhi/python:3.13-debian13-dev AS build
+FROM us-docker.pkg.dev/sentryio/dhi-mirror/python:3.13-debian13-dev AS build
 
 COPY py/ /app/py/
 RUN pip install --no-cache-dir /app/py
 
-FROM us-docker.pkg.dev/sentryio/dhi/python:3.13-debian13
+FROM us-docker.pkg.dev/sentryio/dhi-mirror/python:3.13-debian13
 
 COPY --from=build /opt/python/lib/python3.13/site-packages /opt/python/lib/python3.13/site-packages
 


### PR DESCRIPTION
The build and runtime base images now come from the `dhi-mirror` registry
instead of `dhi`. The image content is unchanged — the same Docker Hardened
Images, pulled through the access mirror.

This is registry-only and does not alter build behavior. Cloud Build
(`cloudbuild.yaml`, via `gcr.io/cloud-builders/docker`) already builds the DHI
base successfully since #62, and the mirror serves identical layers, so no
pipeline changes are required.