### PR TITLE
ci: Build and push the production image via GitHub Actions

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,0 +1,31 @@
+name: image
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-production:
+    runs-on: ubuntu-24.04
+    if: github.ref_name == github.event.repository.default_branch
+    name: Build and push production image
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
+
+      - name: Build and push image
+        uses: getsentry/action-build-and-push-images@b172ab61a5f7eabd58bd42ce231b517e79947c01
+        with:
+          image_name: 'usage-accountant'
+          platforms: linux/amd64
+          dockerfile_path: './Dockerfile'
+          ghcr: false
+          google_ar: true
+          tag_nightly: false
+          tag_latest: true
+          google_ar_image_name: us-central1-docker.pkg.dev/sentryio/usage-accountant/image
+          google_workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
+          google_service_account: gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM us-docker.pkg.dev/sentryio/dhi/python:3.13-debian13-dev AS build
+FROM us-docker.pkg.dev/sentryio/dhi-mirror/python:3.13-debian13-dev AS build
 
 COPY py/ /app/py/
 RUN pip install --no-cache-dir /app/py
 
-FROM us-docker.pkg.dev/sentryio/dhi/python:3.13-debian13
+FROM us-docker.pkg.dev/sentryio/dhi-mirror/python:3.13-debian13
 
 COPY --from=build /opt/python/lib/python3.13/site-packages /opt/python/lib/python3.13/site-packages
 


### PR DESCRIPTION
Move the production image build to GitHub Actions with BuildKit and switch the base images to the `dhi-mirror` registry. These two changes are **coupled** and must land together — neither works alone:

- The old Cloud Build runner cannot unpack `dhi-mirror` (Docker Hardened Image) layers and fails with `archive/tar: invalid tar header`.
- The GitHub Actions identity cannot pull from the `dhi` registry (`403 Forbidden`).

Only `dhi-mirror` built in GitHub Actions satisfies both. This mirrors the sentry-analytics migration in getsentry/sentry-analytics#29.

On the default branch, the `build-production` job builds via `getsentry/action-build-and-push-images` and pushes `us-central1-docker.pkg.dev/sentryio/usage-accountant/image:<github.sha>` — the path GoCD deploys — using the `gha-gcr-push@sac-prod-sa.iam.gserviceaccount.com` service account via Workload Identity Federation. Authorization for this repo to impersonate that account was added in getsentry/security-as-code#3176 (merged and applied).

Verified end to end on a test run: BuildKit pulls both `dhi-mirror` base stages cleanly (no 403, no tar-header error) and the image pushes successfully to `…/usage-accountant/image:<sha>`. The job is gated to the default branch, so it does not build or push on this PR; the push path runs on merge to `main`.

This lands **additively** while Cloud Build remains the deploy gate. A follow-up in `getsentry/ops` flips the GoCD `usage-accountant-k8s` gate to the `Build and push production image` GitHub Actions check run (the pattern in `getsentry/sentry-analytics` `gocd/pipelines/analytics.yaml`) and removes `cloudbuild.yaml`.